### PR TITLE
Add changelog shortlink markdown rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,18 @@ Cordwood is born! {changelog-added-secondary changelog-margin-top}
 
 After about two days of work, Cordwood has been brought into life!
 
-Developed by the lovely team of two, [Beefers](https://github.com/Beefers) and [Alyxia](https://github.com/lexisother), Cordwood is a client mod for Hummus loosely based off of [Cumcord for Discord](https://git.sr.ht/~creatable/Cumcord).
+Developed by the lovely team of two, [Beefers](gh:Beefers) and [Alyxia](gh:lexisother), Cordwood is a client mod for Hummus loosely based off of [Cumcord for Discord](srht:~creatable/Cumcord).
 
 At the moment, we have:
 
 * **Webpack tools:** from `findByDisplayName` to `findByProps`, the basic tools to find Webpack modules are all here.
-* **A patcher** brought to you by [Creatable](https://github.com/cr3atable) and [Yellowsink](https://github.com/Yellowsink), which can be found [here](https://github.com/Cumcord/spitroast).
+* **A patcher** brought to you by [Creatable](gh:cr3atable) and [Yellowsink](gh:Yellowsink), which can be found [here](gh:Cumcord/spitroast).
 * **An epic changelog**. Yeah, we're egotistical like that.
 
-Furthermore, thanks to [Ducko](https://github.com/CanadaHonk) for helping with displaying this very changelog. :)
+Furthermore, thanks to [Ducko](gh:CanadaHonk) for helping with displaying this very changelog. :)
 
 We're cooking up much more exciting features like **plugins**, **themes**, and some epic UI.
 
-You can track development [here](https://github.com/Cordwood/Cordwood), on our cozy little GitHub repo.
+You can track development [here](gh:Cordwood/Cordwood), on our cozy little GitHub repo.
 
 Thanks for reading the first changelog, and we hope you enjoy Cordwood!

--- a/src/ui/settings/components/Changelog.tsx
+++ b/src/ui/settings/components/Changelog.tsx
@@ -38,6 +38,35 @@ const render = MarkupUtils.parserFor({
             );
         },
     },
+    shortlink: {
+        shortlinks: {
+            gh: "github.com",
+            srht: "git.sr.ht",
+        },
+        regex: /^\[(.+?)\]\((.+?):([^\/].+?)\)/,
+        order: DEFAULT_LINK_RULE.order - 0.5,
+
+        match(source: string) {
+            return this.regex.exec(source);
+        },
+
+        parse(capture: Capture, parse: Parser, state: State): UnTypedASTNode | ASTNode {
+            return {
+                content: SimpleMarkdown.parseInline(parse, capture[1], state),
+                target: `https://${this.shortlinks[capture[2] as keyof typeof this.shortlinks]}/${capture[3]}`,
+            };
+        },
+
+        react(node: UnTypedASTNode, output: Output<ReactNode>, state: State) {
+            return React.createElement(
+                "a",
+                {
+                    href: node.target,
+                },
+                output(node.content, state)
+            );
+        },
+    },
 });
 
 export default ({ changelog }: { changelog: { body: string; [key: string]: any } }) => {


### PR DESCRIPTION
This adds a new markdown rule allowing you to use shorthands for commonly used links.

Examples:
 - `[Cordwood](https://github.com/Cordwood/Cordwood)` to `[Cordwood](gh:Cordwood/Cordwood)`
 - `[Cumcord](https://git.sr.ht/~creatable/Cumcord` to `[Cumcord](srht:~creatable/Cumcord)`

There should probably be some sort of error when you use an invalid tag since right now it just converts to `undefined`, however I'm not entirely sure on how to best implement that.